### PR TITLE
Fixed word-break on print version.

### DIFF
--- a/hosting/client/index.css
+++ b/hosting/client/index.css
@@ -28,3 +28,7 @@ body {
 .loading .sk-folding-cube {
     margin: 10% auto;
 }
+
+.card {
+  word-break: normal;
+}


### PR DESCRIPTION
element-ui set word-break in style .el-dialog__body to break-all. This 
is only seen on the print version, since the preview does not use 
el-dialog__body.

The new css selector .card will overwrite this setting to use normal 
word-breaking.